### PR TITLE
fix: file extension . prefix not needed

### DIFF
--- a/pkg/daemon/option.go
+++ b/pkg/daemon/option.go
@@ -417,7 +417,7 @@ func (opf *OptionPathFile) Help() string {
 
 func (opf *OptionPathFile) Set(value string) error {
 	if opf.validate {
-		if filepath.Ext(value) != "."+opf.Format {
+		if filepath.Ext(value) != opf.Format {
 			return InvalidOptionValueError{
 				optionName: opf.name,
 				value:      value,


### PR DESCRIPTION
Fixes | Closes | Resolves #

_Write a short description of the changes here and the motivation behind them_

We don't need a `.` prefix before `opf.Format` because `filepath.Ext` already appends it. Ex: https://go.dev/play/p/n2jL74ielBR



## Changes:
- _List the changes introduced by this PR more in detail here_
- Remove `.` addition for validation

## Types of changes

_Leave on the following list the types of changes introduced by this PR and remove
the ones that don't apply. Please also remove this line._

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing** Yes/No

**In case you checked yes, did you write tests?** Yes/No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
