### PR TITLE
Hardware checker

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -169,3 +169,26 @@ func TestLocalInstall(t *testing.T) {
 	// Run test case
 	e2eTest.run()
 }
+
+func TestInstall_HighRequirements(t *testing.T) {
+	// Test context
+	var (
+		runErr error
+	)
+	// Build test case
+	e2eTest := newE2ETestCase(
+		t,
+		// Arrange
+		nil,
+		// Act
+		func(t *testing.T, egnPath string) {
+			runErr = runCommand(t, egnPath, "install", "--profile", "high-requirements", "--no-prompt", "https://github.com/NethermindEth/mock-avs")
+		},
+		// Assert
+		func(t *testing.T) {
+			assert.Error(t, runErr, "install command should fail")
+		},
+	)
+	// Run test case
+	e2eTest.run()
+}

--- a/internal/hardware_checker/hardware_checker_test.go
+++ b/internal/hardware_checker/hardware_checker_test.go
@@ -93,7 +93,6 @@ func TestHardwareMetrics_Meets(t *testing.T) {
 			got := h.Meets(tt.args.hm)
 			// t.Errorf("HardwareMetrics.Meets() = %v, want %v", got, tt.want)
 			assert.Equal(t, tt.want, got)
-
 		})
 	}
 }

--- a/internal/package_handler/package.go
+++ b/internal/package_handler/package.go
@@ -368,7 +368,7 @@ func (p *PackageHandler) HardwareRequirements(profileName string) (HardwareRequi
 	if err != nil {
 		return HardwareRequirements{}, err
 	}
-	//TODO: Check if we will have to override all the requirements instead of only defined
+	// TODO: Check if we will have to override all the requirements instead of only defined
 	if profile.HardwareRequirementsOverrides != nil {
 		return HardwareRequirements{
 			MinCPUCores:  profile.HardwareRequirementsOverrides.MinCPUCores,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -120,7 +120,7 @@ type PullResult struct {
 
 	// HardwareRequirements is the hardware requirements specified in the package manifest.
 	HardwareRequirements map[string]package_handler.HardwareRequirements
-	//map[Profile]package_handler.HardwareRequirements
+	// map[Profile]package_handler.HardwareRequirements
 }
 
 // InstallOptions is a set of options for installing a node software package.

--- a/pkg/daemon/egn_daemon.go
+++ b/pkg/daemon/egn_daemon.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -710,7 +709,7 @@ func (d *EgnDaemon) CheckHardwareRequirements(requirements hardwarechecker.Hardw
 	// log.Println(">>> ADDRESS FROM PROMETHEUS >>>", address)
 	// metrics, err := hardwarechecker.GetHardwareMetrics(address)
 
-	//log.Infof("Requirements from node: %s", &requirements)
+	// log.Infof("Requirements from node: %s", &requirements)
 	metrics, err := hardwarechecker.GetMetrics()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Implemented a feature that allows checking the hardware requirements of the AVS node to be installed and verifying if the server meets those requirements. Added an end-to-end test to ensure that the installation process fails if the hardware requirements are not met.

## Changes:
- Implemented a feature to check hardware requirements of the AVS node
- Added an end-to-end test for hardware requirements validation

## Types of changes
- New feature (non-breaking change which adds functionality)
- Testing

**Requires testing** Yes

**In case you checked yes, did you write tests?** Yes

**Comments about testing, should you have some** (optional)
The end-to-end test validates that the installation process fails when the hardware requirements are not met. It covers different scenarios to ensure accurate validation.

## Further comments (optional)
This feature was implemented to ensure that the AVS node is installed only on servers that meet the specified hardware requirements. The end-to-end test provides confidence in the correctness of the implementation.