### PR TITLE
Remove volumes when uninstalling

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -67,7 +67,7 @@ func (e *e2eTestCase) Cleanup() {
 	if err != nil {
 		e.t.Log(err)
 	}
-	err = exec.Command("docker", "compose", "-f", filepath.Join(dataDir, "monitoring", "docker-compose.yml"), "down").Run()
+	err = exec.Command("docker", "compose", "-f", filepath.Join(dataDir, "monitoring", "docker-compose.yml"), "down", "--volumes").Run()
 	if err != nil {
 		e.t.Logf("error removing monitoring stack. It is possible that the monitoring stack wasn't installed and this is intentional: %v", err)
 	}
@@ -86,7 +86,7 @@ func (e *e2eTestCase) Cleanup() {
 		for _, entry := range dirEntries {
 			if entry.IsDir() {
 				e.t.Logf("Removing node %s", entry.Name())
-				err := exec.Command("docker", "compose", "-f", filepath.Join(dataDir, "nodes", entry.Name(), "docker-compose.yml"), "down").Run()
+				err := exec.Command("docker", "compose", "-f", filepath.Join(dataDir, "nodes", entry.Name(), "docker-compose.yml"), "down", "--volumes").Run()
 				if err != nil {
 					e.t.Logf("error removing node %s: %v", entry.Name(), err)
 				}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -156,6 +156,10 @@ func (cm *ComposeManager) Stop(opts DockerComposeStopOptions) error {
 func (cm *ComposeManager) Down(opts DockerComposeDownOptions) error {
 	downCmd := fmt.Sprintf("docker compose -f %s down", opts.Path)
 
+	if opts.Volumes {
+		downCmd += " --volumes"
+	}
+
 	if out, exitCode, err := cm.cmdRunner.RunCMD(commands.Command{Cmd: downCmd, GetOutput: true}); err != nil || exitCode != 0 {
 		return fmt.Errorf("%w: %s. Output: %s", DockerComposeCmdError{cmd: "down"}, err, out)
 	}

--- a/internal/compose/types.go
+++ b/internal/compose/types.go
@@ -75,4 +75,6 @@ type DockerComposeStopOptions struct {
 type DockerComposeDownOptions struct {
 	// Path specifies the location of the docker-compose.yaml file.
 	Path string
+	// Remove named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers.
+	Volumes bool
 }

--- a/pkg/daemon/egn_daemon.go
+++ b/pkg/daemon/egn_daemon.go
@@ -742,7 +742,8 @@ func (d *EgnDaemon) uninstall(instanceID string, down bool) error {
 		composePath := path.Join(instancePath, "docker-compose.yml")
 		// docker compose down
 		if err = d.dockerCompose.Down(compose.DockerComposeDownOptions{
-			Path: composePath,
+			Path:    composePath,
+			Volumes: true,
 		}); err != nil {
 			return err
 		}

--- a/pkg/daemon/egn_daemon_test.go
+++ b/pkg/daemon/egn_daemon_test.go
@@ -1315,7 +1315,7 @@ func TestUninstall(t *testing.T) {
 					monitoringManager.EXPECT().InstallationStatus().Return(common.Installed, nil),
 					monitoringManager.EXPECT().Status().Return(common.Running, nil),
 					monitoringManager.EXPECT().RemoveTarget("mock-avs-default").Return(nil),
-					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path}).Return(nil),
+					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path, Volumes: true}).Return(nil),
 				)
 			},
 			options: &InstallOptions{
@@ -1340,7 +1340,7 @@ func TestUninstall(t *testing.T) {
 					composeManager.EXPECT().Create(compose.DockerComposeCreateOptions{Path: path, Build: true}).Return(nil),
 					// Uninstall
 					monitoringManager.EXPECT().InstallationStatus().Return(common.NotInstalled, nil),
-					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path}).Return(nil),
+					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path, Volumes: true}).Return(nil),
 				)
 			},
 			options: &InstallOptions{
@@ -1366,7 +1366,7 @@ func TestUninstall(t *testing.T) {
 					// Uninstall
 					monitoringManager.EXPECT().InstallationStatus().Return(common.Installed, nil),
 					monitoringManager.EXPECT().Status().Return(common.Unknown, nil),
-					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path}).Return(nil),
+					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path, Volumes: true}).Return(nil),
 				)
 			},
 			options: &InstallOptions{
@@ -1399,7 +1399,7 @@ func TestUninstall(t *testing.T) {
 					monitoringManager.EXPECT().InstallationStatus().Return(common.Installed, nil),
 					monitoringManager.EXPECT().Status().Return(common.Running, nil),
 					monitoringManager.EXPECT().RemoveTarget("mock-avs-default").Return(nil),
-					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path}).Return(errors.New("error")),
+					composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: path, Volumes: true}).Return(errors.New("error")),
 				)
 			},
 			options: &InstallOptions{

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -274,7 +274,7 @@ func (m *MonitoringManager) InstallationStatus() (common.Status, error) {
 func (m *MonitoringManager) Cleanup(force bool) error {
 	if !force {
 		log.Info("Shutting down monitoring stack...")
-		if err := m.composeManager.Down(compose.DockerComposeDownOptions{Path: filepath.Join(m.stack.Path(), "docker-compose.yml")}); err != nil {
+		if err := m.composeManager.Down(compose.DockerComposeDownOptions{Path: filepath.Join(m.stack.Path(), "docker-compose.yml"), Volumes: true}); err != nil {
 			return fmt.Errorf("%w: %w", ErrRunningMonitoringStack, err)
 		}
 	}

--- a/pkg/monitoring/monitoring_test.go
+++ b/pkg/monitoring/monitoring_test.go
@@ -1539,7 +1539,7 @@ func TestCleanup(t *testing.T) {
 			name: "ok, force false",
 			mocker: func(t *testing.T, ctrl *gomock.Controller) (*mocks.MockComposeManager, *mock_locker.MockLocker) {
 				composeManager := mocks.NewMockComposeManager(ctrl)
-				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath}).Return(nil)
+				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath, Volumes: true}).Return(nil)
 
 				locker := mock_locker.NewMockLocker(ctrl)
 				gomock.InOrder(
@@ -1574,7 +1574,7 @@ func TestCleanup(t *testing.T) {
 			name: "down error",
 			mocker: func(t *testing.T, ctrl *gomock.Controller) (*mocks.MockComposeManager, *mock_locker.MockLocker) {
 				composeManager := mocks.NewMockComposeManager(ctrl)
-				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath}).Return(errors.New("error"))
+				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath, Volumes: true}).Return(errors.New("error"))
 
 				locker := mock_locker.NewMockLocker(ctrl)
 				gomock.InOrder(
@@ -1592,7 +1592,7 @@ func TestCleanup(t *testing.T) {
 			name: "ok, force false, no install",
 			mocker: func(t *testing.T, ctrl *gomock.Controller) (*mocks.MockComposeManager, *mock_locker.MockLocker) {
 				composeManager := mocks.NewMockComposeManager(ctrl)
-				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath}).Return(nil)
+				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath, Volumes: true}).Return(nil)
 
 				locker := mock_locker.NewMockLocker(ctrl)
 				locker.EXPECT().New(filepath.Join(userDataHome, ".eigen", "monitoring", ".lock")).Return(locker)
@@ -1606,7 +1606,7 @@ func TestCleanup(t *testing.T) {
 			name: "stack cleanup error, lock error",
 			mocker: func(t *testing.T, ctrl *gomock.Controller) (*mocks.MockComposeManager, *mock_locker.MockLocker) {
 				composeManager := mocks.NewMockComposeManager(ctrl)
-				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath}).Return(nil)
+				composeManager.EXPECT().Down(compose.DockerComposeDownOptions{Path: composePath, Volumes: true}).Return(nil)
 
 				locker := mock_locker.NewMockLocker(ctrl)
 				gomock.InOrder(


### PR DESCRIPTION

## Changes:

- Use the `--volumes` flag in `docker compose down` commands to remove volumes when uninstalling an AVS node or cleaning the monitoring stack.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing** Yes

**In case you checked yes, did you write tests?** No. Updating the current test cases is enough to ensure that the flag is used.

