### PR TITLE
Update mock-avs version management for E2E

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -43,7 +43,7 @@ func TestInstall_ValidArgument(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			return buildMockAvsImages(t)
+			return buildMockAvsImagesLatest(t)
 		},
 		// Act
 		func(t *testing.T, egnPath string) {
@@ -73,7 +73,7 @@ func TestInstall_FromCommitHash(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			return buildMockAvsImages(t)
+			return buildMockAvsImagesLatest(t)
 		},
 		// Act
 		func(t *testing.T, egnPath string) {
@@ -103,7 +103,7 @@ func TestInstall_ValidArgumentWithMonitoring(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")
@@ -145,7 +145,7 @@ func TestInstall_ValidArgumentNotRun(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			return buildMockAvsImages(t)
+			return buildMockAvsImagesLatest(t)
 		},
 		// Act
 		func(t *testing.T, egnPath string) {
@@ -172,7 +172,7 @@ func TestInstall_DuplicatedID(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			return runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--tag", "integration", "--yes", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -205,7 +205,7 @@ func TestInstall_DuplicatedContainerNameWithMonitoring(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")
@@ -252,7 +252,7 @@ func TestInstall_MultipleAVS(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			return buildMockAvsImages(t)
+			return buildMockAvsImagesLatest(t)
 		},
 		// Act
 		func(t *testing.T, egnPath string) {
@@ -293,7 +293,7 @@ func TestInstall_MultipleAVSWithMonitoring(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")
@@ -349,7 +349,7 @@ func TestInstall_HighRequirements(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			return buildMockAvsImages(t)
+			return buildMockAvsImagesLatest(t)
 		},
 		// Act
 		func(t *testing.T, egnPath string) {
@@ -376,7 +376,7 @@ func TestInstall_ProfileWithHiddenOptionsNotSet(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			return buildMockAvsImages(t)
+			return buildMockAvsImagesLatest(t)
 		},
 		// Act
 		func(t *testing.T, egnPath string) {

--- a/e2e/local_install_test.go
+++ b/e2e/local_install_test.go
@@ -22,7 +22,7 @@ func TestLocalInstall(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := os.MkdirAll(pkgDir, 0o755)
@@ -66,7 +66,7 @@ func TestLocalInstallNotRunning(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := os.MkdirAll(pkgDir, 0o755)
@@ -107,7 +107,7 @@ func TestLocalInstallWithMonitoring(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")
@@ -160,7 +160,7 @@ func TestLocalInstallInvalidManifest(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := os.MkdirAll(pkgDir, 0o755)
@@ -207,7 +207,7 @@ func TestLocalInstallInvalidManifestCleanup(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := os.MkdirAll(pkgDir, 0o755)
@@ -255,7 +255,7 @@ func TestLocalInstallInvalidManifestCleanupWithMonitoring(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")
@@ -309,7 +309,7 @@ func TestLocalInstallInvalidComposeCleanup(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := os.MkdirAll(pkgDir, 0o755)
@@ -356,7 +356,7 @@ func TestLocalInstall_DuplicatedContainerNameWithMonitoring(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")
@@ -418,7 +418,7 @@ func TestLocalInstall_ProfileWithHiddenOptionsNotSet(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := os.MkdirAll(pkgDir, 0o755)

--- a/e2e/ls_test.go
+++ b/e2e/ls_test.go
@@ -41,7 +41,7 @@ func TestLs_NotRunning(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, eigenlayerPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func TestLs_RunningHealthy(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, eigenlayerPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ func TestLs_RunningPartiallyHealthy(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, eigenlayerPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -134,7 +134,7 @@ func TestLs_RunningUnhealthy(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, eigenlayerPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func TestLs_Comment(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, eigenlayerPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}

--- a/e2e/monitoring_stack_test.go
+++ b/e2e/monitoring_stack_test.go
@@ -133,7 +133,7 @@ func TestMonitoring_Restart(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "init-monitoring")

--- a/e2e/plugin_test.go
+++ b/e2e/plugin_test.go
@@ -28,7 +28,7 @@ func TestPlugin_LocalInstall(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			if err := os.MkdirAll(pkgDir, 0o755); err != nil {
@@ -101,7 +101,7 @@ func TestPlugin_Install_Run(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			return runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--yes", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -124,7 +124,7 @@ func TestPlugin_Install_Run(t *testing.T) {
 			require.NoError(t, err, "docker events should succeed")
 
 			events.CheckInOrder(t,
-				docker.NewContainerCreated(common.PluginImage.Image(), &pluginContainerID),
+				docker.NewContainerCreated(common.PluginImage.FullImage(), &pluginContainerID),
 				docker.NewNetworkConnect(&pluginContainerID, &networkID),
 				docker.NewNetworkDisconnect(&pluginContainerID, &networkID),
 				docker.NewContainerDies(&pluginContainerID),
@@ -148,7 +148,7 @@ func TestPlugin_Volume_File(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--yes", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -188,7 +188,7 @@ func TestPlugin_Volume_File(t *testing.T) {
 			require.NoError(t, err, "docker events should succeed")
 
 			events.CheckInOrder(t,
-				docker.NewContainerCreated(common.PluginImage.Image(), &pluginContainerID),
+				docker.NewContainerCreated(common.PluginImage.FullImage(), &pluginContainerID),
 				docker.NewNetworkConnect(&pluginContainerID, &networkID),
 				docker.NewNetworkDisconnect(&pluginContainerID, &networkID),
 				docker.NewContainerDies(&pluginContainerID),
@@ -213,7 +213,7 @@ func TestPlugin_Volume_Existing_Dir(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--yes", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -255,7 +255,7 @@ func TestPlugin_Volume_Existing_Dir(t *testing.T) {
 			require.NoError(t, err, "docker events should succeed")
 
 			events.CheckInOrder(t,
-				docker.NewContainerCreated(common.PluginImage.Image(), &pluginContainerID),
+				docker.NewContainerCreated(common.PluginImage.FullImage(), &pluginContainerID),
 				docker.NewNetworkConnect(&pluginContainerID, &networkID),
 				docker.NewNetworkDisconnect(&pluginContainerID, &networkID),
 				docker.NewContainerDies(&pluginContainerID),
@@ -280,7 +280,7 @@ func TestPlugin_Volume_NonExisting_Dir(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--yes", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -320,7 +320,7 @@ func TestPlugin_Volume_NonExisting_Dir(t *testing.T) {
 			require.NoError(t, err, "docker events should succeed")
 
 			events.CheckInOrder(t,
-				docker.NewContainerCreated(common.PluginImage.Image(), &pluginContainerID),
+				docker.NewContainerCreated(common.PluginImage.FullImage(), &pluginContainerID),
 				docker.NewNetworkConnect(&pluginContainerID, &networkID),
 				docker.NewNetworkDisconnect(&pluginContainerID, &networkID),
 				docker.NewContainerDies(&pluginContainerID),
@@ -342,7 +342,7 @@ func TestPlugin_Install_Run_HostNetwork(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			return runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -363,7 +363,7 @@ func TestPlugin_Install_Run_HostNetwork(t *testing.T) {
 			require.NoError(t, err, "docker events should succeed")
 
 			events.CheckInOrder(t,
-				docker.NewContainerCreated(common.PluginImage.Image(), &pluginContainerID),
+				docker.NewContainerCreated(common.PluginImage.FullImage(), &pluginContainerID),
 				docker.NewContainerDies(&pluginContainerID),
 				docker.NewContainerDestroy(&pluginContainerID),
 			)
@@ -385,7 +385,7 @@ func TestPlugin_ExitsWithError(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			if err := buildMockAvsImages(t); err != nil {
+			if err := buildMockAvsImagesLatest(t); err != nil {
 				return err
 			}
 			err := runCommand(t, egnPath, "install", "--profile", "option-returner", "--no-prompt", "--yes", "--version", common.MockAvsPkg.Version(), "--option.test-option-hidden", "12345678", "--option.test-option-enum-hidden", "option3", common.MockAvsPkg.Repo())
@@ -425,7 +425,7 @@ func TestPlugin_ExitsWithError(t *testing.T) {
 			require.NoError(t, err, "docker events should succeed")
 
 			events.CheckInOrder(t,
-				docker.NewContainerCreated(common.PluginImage.Image(), &pluginContainerID),
+				docker.NewContainerCreated(common.PluginImage.FullImage(), &pluginContainerID),
 				docker.NewNetworkConnect(&pluginContainerID, &networkID),
 				docker.NewNetworkDisconnect(&pluginContainerID, &networkID),
 				docker.NewContainerDies(&pluginContainerID),

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -18,7 +18,7 @@ func Test_Run(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -46,7 +46,7 @@ func Test_Run_StoppedInstance(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func Test_Run_AlreadyRunningInstance(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}

--- a/e2e/stop_test.go
+++ b/e2e/stop_test.go
@@ -18,7 +18,7 @@ func Test_Stop(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}

--- a/e2e/uninstall_test.go
+++ b/e2e/uninstall_test.go
@@ -18,7 +18,7 @@ func Test_Uninstall(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -51,7 +51,7 @@ func Test_Uninstall_After_Stop(t *testing.T) {
 	)
 	e2eTest := newE2ETestCase(t,
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}

--- a/e2e/update_test.go
+++ b/e2e/update_test.go
@@ -20,7 +20,11 @@ func TestUpdate(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesCustomTag(t, "v0.1.0")
+			if err != nil {
+				return err
+			}
+			err = buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -53,7 +57,11 @@ func TestUpdate_Run(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesCustomTag(t, "v0.1.0")
+			if err != nil {
+				return err
+			}
+			err = buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -88,7 +96,7 @@ func TestUpdate_SameVersion(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -124,7 +132,7 @@ func TestUpdate_OldVersion(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -152,7 +160,7 @@ func TestUpdate_SameCommit(t *testing.T) {
 	// Test context
 	var (
 		installVersion = common.MockAvsPkg.Version()
-		updateCommit   = "a3406616b848164358fdd24465b8eecda5f5ae34"
+		updateCommit   = common.MockAvsPkg.CommitHash()
 		updateError    error
 	)
 	// Build test case
@@ -160,7 +168,7 @@ func TestUpdate_SameCommit(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}
@@ -196,7 +204,7 @@ func TestUpdate_OldCommit(t *testing.T) {
 		t,
 		// Arrange
 		func(t *testing.T, egnPath string) error {
-			err := buildMockAvsImages(t)
+			err := buildMockAvsImagesLatest(t)
 			if err != nil {
 				return err
 			}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -35,17 +35,30 @@ func runCommandOutput(t *testing.T, path string, args ...string) ([]byte, error)
 	return out, err
 }
 
-func buildMockAvsImages(t *testing.T) error {
+func buildMockAvsImagesLatest(t *testing.T) error {
 	t.Helper()
-	err := runCommand(t, "docker", "build", "-t", common.OptionReturnerImage.Image(), "https://github.com/NethermindEth/mock-avs.git#main:option-returner")
+	err := runCommand(t, "docker", "build", "-t", common.OptionReturnerImage.FullImage(), "https://github.com/NethermindEth/mock-avs.git#main:option-returner")
 	if err != nil {
 		return err
 	}
-	err = runCommand(t, "docker", "build", "-t", common.PluginImage.Image(), "https://github.com/NethermindEth/mock-avs.git#main:plugin")
+	err = runCommand(t, "docker", "build", "-t", common.PluginImage.FullImage(), "https://github.com/NethermindEth/mock-avs.git#main:plugin")
 	if err != nil {
 		return err
 	}
-	return runCommand(t, "docker", "build", "-t", common.HealthCheckerImage.Image(), "https://github.com/NethermindEth/mock-avs.git#main:health-checker")
+	return runCommand(t, "docker", "build", "-t", common.HealthCheckerImage.FullImage(), "https://github.com/NethermindEth/mock-avs.git#main:health-checker")
+}
+
+func buildMockAvsImagesCustomTag(t *testing.T, tag string) error {
+	t.Helper()
+	err := runCommand(t, "docker", "build", "-t", common.OptionReturnerImage.Image()+":"+tag, "https://github.com/NethermindEth/mock-avs.git#main:option-returner")
+	if err != nil {
+		return err
+	}
+	err = runCommand(t, "docker", "build", "-t", common.PluginImage.Image()+":"+tag, "https://github.com/NethermindEth/mock-avs.git#main:plugin")
+	if err != nil {
+		return err
+	}
+	return runCommand(t, "docker", "build", "-t", common.HealthCheckerImage.Image()+":"+tag, "https://github.com/NethermindEth/mock-avs.git#main:health-checker")
 }
 
 func repoPath(t *testing.T) string {

--- a/internal/common/mock-avs.go
+++ b/internal/common/mock-avs.go
@@ -56,16 +56,26 @@ func (m *MockAVS) CommitHash() string {
 
 type MockAVSImage struct {
 	image string
+	tag   string
 }
 
 func NewMockAVSImage(image, tag string) *MockAVSImage {
 	return &MockAVSImage{
-		image: fmt.Sprintf("%s:%s", image, tag),
+		image: image,
+		tag:   tag,
 	}
 }
 
 func (m *MockAVSImage) Image() string {
 	return m.image
+}
+
+func (m *MockAVSImage) Tag() string {
+	return m.tag
+}
+
+func (m *MockAVSImage) FullImage() string {
+	return fmt.Sprintf("%s:%s", m.image, m.tag)
 }
 
 type Tag struct {

--- a/internal/data/instance_test.go
+++ b/internal/data/instance_test.go
@@ -126,7 +126,7 @@ func TestNewInstance(t *testing.T) {
 				"profile":"mainnet",
 				"tag":"test_tag",
 				"plugin":{
-					"image":"`+common.PluginImage.Image()+`"
+					"image":"`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 			if err != nil {
@@ -144,7 +144,7 @@ func TestNewInstance(t *testing.T) {
 					Commit:  common.MockAvsPkg.CommitHash(),
 					Profile: "mainnet",
 					Plugin: &Plugin{
-						Image: common.PluginImage.Image(),
+						Image: common.PluginImage.FullImage(),
 					},
 					path: testDir,
 				},

--- a/pkg/daemon/egn_daemon_test.go
+++ b/pkg/daemon/egn_daemon_test.go
@@ -2830,7 +2830,7 @@ func TestRunPlugin(t *testing.T) {
 					"profile": "option-returner",
 					"url": "`+common.MockAvsPkg.Repo()+`",
 					"plugin": {
-						"image": "`+common.PluginImage.Image()+`"
+						"image": "`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 				gomock.InOrder(
@@ -2844,7 +2844,7 @@ func TestRunPlugin(t *testing.T) {
 						},
 					}, nil),
 					d.dockerManager.EXPECT().ContainerNetworks("abc123").Return([]string{"network-el"}, nil),
-					d.dockerManager.EXPECT().Run(common.PluginImage.Image(), "network-el", []string{"arg1", "arg2"}, []docker.Mount{
+					d.dockerManager.EXPECT().Run(common.PluginImage.FullImage(), "network-el", []string{"arg1", "arg2"}, []docker.Mount{
 						{
 							Type:   docker.VolumeTypeBind,
 							Source: "/tmp",
@@ -2856,7 +2856,7 @@ func TestRunPlugin(t *testing.T) {
 							Target: "/tmp/volume1",
 						},
 					}),
-					d.dockerManager.EXPECT().ImageRemove(common.PluginImage.Image()).Return(nil),
+					d.dockerManager.EXPECT().ImageRemove(common.PluginImage.FullImage()).Return(nil),
 				)
 			},
 		},
@@ -2881,11 +2881,11 @@ func TestRunPlugin(t *testing.T) {
 					"profile": "option-returner",
 					"url": "`+common.MockAvsPkg.Repo()+`",
 					"plugin": {
-						"image": "`+common.PluginImage.Image()+`"
+						"image": "`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 				gomock.InOrder(
-					d.dockerManager.EXPECT().Run(common.PluginImage.Image(), docker.NetworkHost, []string{"arg1", "arg2"}, []docker.Mount{
+					d.dockerManager.EXPECT().Run(common.PluginImage.FullImage(), docker.NetworkHost, []string{"arg1", "arg2"}, []docker.Mount{
 						{
 							Type:   docker.VolumeTypeBind,
 							Source: "/tmp",
@@ -2897,7 +2897,7 @@ func TestRunPlugin(t *testing.T) {
 							Target: "/tmp/volume1",
 						},
 					}),
-					d.dockerManager.EXPECT().ImageRemove(common.PluginImage.Image()).Return(nil),
+					d.dockerManager.EXPECT().ImageRemove(common.PluginImage.FullImage()).Return(nil),
 				)
 			},
 		},
@@ -2932,7 +2932,7 @@ func TestRunPlugin(t *testing.T) {
 					"profile": "option-returner",
 					"url": "`+common.MockAvsPkg.Repo()+`",
 					"plugin": {
-						"image": "`+common.PluginImage.Image()+`"
+						"image": "`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 				d.composeManager.EXPECT().PS(compose.DockerComposePsOptions{
@@ -2954,7 +2954,7 @@ func TestRunPlugin(t *testing.T) {
 					"profile": "option-returner",
 					"url": "`+common.MockAvsPkg.Repo()+`",
 					"plugin": {
-						"image": "`+common.PluginImage.Image()+`"
+						"image": "`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 				d.composeManager.EXPECT().PS(compose.DockerComposePsOptions{
@@ -2976,7 +2976,7 @@ func TestRunPlugin(t *testing.T) {
 					"profile": "option-returner",
 					"url": "`+common.MockAvsPkg.Repo()+`",
 					"plugin": {
-						"image": "`+common.PluginImage.Image()+`"
+						"image": "`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 				d.composeManager.EXPECT().PS(compose.DockerComposePsOptions{
@@ -3003,7 +3003,7 @@ func TestRunPlugin(t *testing.T) {
 					"profile": "option-returner",
 					"url": "`+common.MockAvsPkg.Repo()+`",
 					"plugin": {
-						"image": "`+common.PluginImage.Image()+`"
+						"image": "`+common.PluginImage.FullImage()+`"
 					}
 				}`)
 				d.composeManager.EXPECT().PS(compose.DockerComposePsOptions{


### PR DESCRIPTION
Fixes | Closes | Resolves #

## Changes:

- Add `tag` property to the `MockAVSImage` to support custom versions in the E2E

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing** No