### PR TITLE
adding import key cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce and validate password on key creation. ([#89](https://github.com/NethermindEth/eigenlayer/pull/89))
 - Add `restore` command. ([#90](https://github.com/NethermindEth/eigenlayer/pull/90))
   - Upgrade `update` command to support backing up the old instance and restoring from a backup if the update fails.
+- Add `keys import` command  ([#97](https://github.com/NethermindEth/eigenlayer/pull/97))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ You can create encrypted ecdsa and bls keys using the cli which will be needed f
 eigenlayer operator keys create --key-type ecdsa [keyname]
 eigenlayer operator keys create --key-type bls [keyname]
 ```
-- `keyname` - This will be name of the created key file. It will be saved as `<keyname>.ecdsa.key.json` or `<keyname>.bls.key.json`
+- `keyname` - This will be the name of the created key file. It will be saved as `<keyname>.ecdsa.key.json` or `<keyname>.bls.key.json`
 
 This will prompt a password which you can use to encrypt the keys. Keys will be stored in local disk and will be shown once keys are created.
 It will also show the private key only once, so that you can back it up in case you lose the password or keyfile.
@@ -478,7 +478,7 @@ You can import existing ecdsa and bls keys using the cli which will be needed fo
 eigenlayer operator keys import --key-type ecdsa [keyname] [privatekey]
 eigenlayer operator keys import --key-type bls [keyname] [privatekey]
 ```
-- `keyname` - This will be name of the imported key file. It will be saved as `<keyname>.ecdsa.key.json` or `<keyname>.bls.key.json`
+- `keyname` - This will be the name of the imported key file. It will be saved as `<keyname>.ecdsa.key.json` or `<keyname>.bls.key.json`
 - `privatekey` - This will be the private key of the key to be imported.
   - For ecdsa key, it should be in hex format
   - For bls key, it should be a large number

--- a/README.md
+++ b/README.md
@@ -445,8 +445,17 @@ In this case, the plugin container receives the `--port 8080` arguments. Note th
 You can create encrypted ecdsa and bls keys using the cli which will be needed for operator registration and other onchain calls
 
 ```bash
-eigenlayer operator keys create  --key-type ecdsa [keyname]
-eigenlayer operator keys create  --key-type bls [keyname]
+eigenlayer operator keys create --key-type ecdsa [keyname]
+eigenlayer operator keys create --key-type bls [keyname]
+```
+
+### Import keys
+
+You can import existing ecdsa and bls keys using the cli which will be needed for operator registration and other onchain calls
+
+```bash
+eigenlayer operator keys import --key-type ecdsa [keyname] [privatekey]
+eigenlayer operator keys create --key-type bls [keyname] [privatekey]
 ```
 
 This will prompt a password which you can use to encrypt the keys. Keys will be stored in local disk and will be shown once keys are created.

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ You can import existing ecdsa and bls keys using the cli which will be needed fo
 
 ```bash
 eigenlayer operator keys import --key-type ecdsa [keyname] [privatekey]
-eigenlayer operator keys create --key-type bls [keyname] [privatekey]
+eigenlayer operator keys import --key-type bls [keyname] [privatekey]
 ```
 
 This will prompt a password which you can use to encrypt the keys. Keys will be stored in local disk and will be shown once keys are created.

--- a/README.md
+++ b/README.md
@@ -448,6 +448,27 @@ You can create encrypted ecdsa and bls keys using the cli which will be needed f
 eigenlayer operator keys create --key-type ecdsa [keyname]
 eigenlayer operator keys create --key-type bls [keyname]
 ```
+- `keyname` - This will be name of the created key file. It will be saved as `<keyname>.ecdsa.key.json` or `<keyname>.bls.key.json`
+
+This will prompt a password which you can use to encrypt the keys. Keys will be stored in local disk and will be shown once keys are created.
+It will also show the private key only once, so that you can back it up in case you lose the password or keyfile.
+
+Example:
+
+Input command
+```bash
+eigenlayer operator keys create --key-type ecdsa test
+```
+Output
+```bash
+? Enter password to encrypt the ecdsa private key: *******
+ECDSA Private Key (Hex):  6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6
+Please backup the above private key hex in safe place.
+
+Key location: ./operator_keys/test.ecdsa.key.json
+a30264c19cd7292d5153da9c9df58f81aced417e8587dd339021c45ee61f20d55f4c3d374d6f472d3a2c4382e2a9770db395d60756d3b3ea97e8c1f9013eb1bb
+0x9F664973BF656d6077E66973c474cB58eD5E97E1
+```
 
 ### Import keys
 
@@ -456,6 +477,27 @@ You can import existing ecdsa and bls keys using the cli which will be needed fo
 ```bash
 eigenlayer operator keys import --key-type ecdsa [keyname] [privatekey]
 eigenlayer operator keys import --key-type bls [keyname] [privatekey]
+```
+- `keyname` - This will be name of the imported key file. It will be saved as `<keyname>.ecdsa.key.json` or `<keyname>.bls.key.json`
+- `privatekey` - This will be the private key of the key to be imported.
+  - For ecdsa key, it should be in hex format
+  - For bls key, it should be a large number
+
+Example:
+
+Input command
+```bash
+eigenlayer operator keys import --key-type ecdsa test 6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6
+```
+Output
+```bash
+? Enter password to encrypt the ecdsa private key: *******
+ECDSA Private Key (Hex):  6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6
+Please backup the above private key hex in safe place.
+
+Key location: ./operator_keys/test.ecdsa.key.json
+a30264c19cd7292d5153da9c9df58f81aced417e8587dd339021c45ee61f20d55f4c3d374d6f472d3a2c4382e2a9770db395d60756d3b3ea97e8c1f9013eb1bb
+0x9F664973BF656d6077E66973c474cB58eD5E97E1
 ```
 
 This will prompt a password which you can use to encrypt the keys. Keys will be stored in local disk and will be shown once keys are created.

--- a/cli/operator/keys.go
+++ b/cli/operator/keys.go
@@ -15,6 +15,7 @@ func KeysCmd(p prompter.Prompter) *cobra.Command {
 	cmd.AddCommand(
 		keys.CreateCmd(p),
 		keys.ListCmd(p),
+		keys.ImportCmd(p),
 	)
 
 	return &cmd

--- a/cli/operator/keys/create.go
+++ b/cli/operator/keys/create.go
@@ -44,7 +44,7 @@ func CreateCmd(p prompter.Prompter) *cobra.Command {
 		Long: `
 Used to create ecdsa and bls key in local keystore
 
-keyname is required
+keyname (required) - This will be name of the created key file. It will be saved as <keyname>.ecdsa.key.json or <keyname>.bls.key.json
 
 use --key-type ecdsa/bls to create ecdsa/bls key. 
 It will prompt for password to encrypt the key, which is optional but highly recommended.

--- a/cli/operator/keys/create.go
+++ b/cli/operator/keys/create.go
@@ -88,88 +88,23 @@ This command will create keys in ./operator_keys/ location
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keyName := args[0]
-			basePath, _ := os.Getwd()
 
 			switch keyType {
 			case KeyTypeECDSA:
-				keyFileName := keyName + ".ecdsa.key.json"
-				if checkIfKeyExists(keyFileName) {
-					return errors.New("key name already exists. Please choose a different name")
-				}
-
 				privateKey, err := crypto.GenerateKey()
 				if err != nil {
 					return err
 				}
-
-				password, err := p.InputHiddenString("Enter password to encrypt the ecdsa private key:", "",
-					func(s string) error {
-						if insecure {
-							return nil
-						}
-						return validatePassword(s)
-					},
-				)
-				if err != nil {
-					return err
-				}
-
-				err = WriteEncryptedECDSAPrivateKeyToPath(keyFileName, privateKey, password)
-				if err != nil {
-					return err
-				}
-
-				privateKeyHex := hex.EncodeToString(privateKey.D.Bytes())
-				// TODO: display it using `less` of `vi` so that it is not saved in terminal history
-				fmt.Println("ECDSA Private Key (Hex): ", privateKeyHex)
-				fmt.Println("Please backup the above private key hex in safe place.")
-				fmt.Println()
-				fmt.Println("Key location: " + basePath + "/" + OperatorKeyFolder + "/" + keyFileName)
-				publicKey := privateKey.Public()
-				publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
-				if !ok {
-					return err
-				}
-				publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
-				fmt.Println(hexutil.Encode(publicKeyBytes)[4:])
-				address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
-				fmt.Println(address)
-
-				return nil
+				return saveEcdsaKey(keyName, p, privateKey, insecure)
 			case KeyTypeBLS:
-				keyFileName := keyName + ".bls.key.json"
-				if checkIfKeyExists(keyFileName) {
-					return errors.New("key name already exists. Please choose a different name")
-				}
-				password, err := p.InputHiddenString("Enter password to encrypt the bls private key:", "",
-					func(s string) error {
-						if insecure {
-							return nil
-						}
-						return validatePassword(s)
-					},
-				)
-				if err != nil {
-					return err
-				}
 				blsKeyPair, err := bls.GenRandomBlsKeys()
 				if err != nil {
 					return err
 				}
-				err = blsKeyPair.SaveToFile(OperatorKeyFolder+"/"+keyFileName, password)
-				if err != nil {
-					return err
-				}
-				// TODO: display it using `less` of `vi` so that it is not saved in terminal history
-				fmt.Println("BLS Private Key: " + blsKeyPair.PrivKey.String())
-				fmt.Println("Please backup the above private key in safe place.")
-				fmt.Println()
-				fmt.Println("BLS Pub key: " + blsKeyPair.PubKey.String())
-				fmt.Println("Key location: " + basePath + "/" + OperatorKeyFolder + "/" + keyFileName)
+				return saveBlsKey(keyName, p, blsKeyPair, insecure)
 			default:
 				return ErrInvalidKeyType
 			}
-			return nil
 		},
 	}
 
@@ -177,6 +112,79 @@ This command will create keys in ./operator_keys/ location
 	cmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Use this flag to skip password validation")
 
 	return &cmd
+}
+
+func saveBlsKey(keyName string, p prompter.Prompter, keyPair *bls.KeyPair, insecure bool) error {
+	basePath, _ := os.Getwd()
+	keyFileName := keyName + ".bls.key.json"
+	if checkIfKeyExists(keyFileName) {
+		return errors.New("key name already exists. Please choose a different name")
+	}
+	password, err := p.InputHiddenString("Enter password to encrypt the bls private key:", "",
+		func(s string) error {
+			if insecure {
+				return nil
+			}
+			return validatePassword(s)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = keyPair.SaveToFile(OperatorKeyFolder+"/"+keyFileName, password)
+	if err != nil {
+		return err
+	}
+	// TODO: display it using `less` of `vi` so that it is not saved in terminal history
+	fmt.Println("BLS Private Key: " + keyPair.PrivKey.String())
+	fmt.Println("Please backup the above private key in safe place.")
+	fmt.Println()
+	fmt.Println("BLS Pub key: " + keyPair.PubKey.String())
+	fmt.Println("Key location: " + basePath + "/" + OperatorKeyFolder + "/" + keyFileName)
+	return nil
+}
+
+func saveEcdsaKey(keyName string, p prompter.Prompter, privateKey *ecdsa.PrivateKey, insecure bool) error {
+	basePath, _ := os.Getwd()
+	keyFileName := keyName + ".ecdsa.key.json"
+	if checkIfKeyExists(keyFileName) {
+		return errors.New("key name already exists. Please choose a different name")
+	}
+
+	password, err := p.InputHiddenString("Enter password to encrypt the ecdsa private key:", "",
+		func(s string) error {
+			if insecure {
+				return nil
+			}
+			return validatePassword(s)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = WriteEncryptedECDSAPrivateKeyToPath(keyFileName, privateKey, password)
+	if err != nil {
+		return err
+	}
+
+	privateKeyHex := hex.EncodeToString(privateKey.D.Bytes())
+	// TODO: display it using `less` of `vi` so that it is not saved in terminal history
+	fmt.Println("ECDSA Private Key (Hex): ", privateKeyHex)
+	fmt.Println("Please backup the above private key hex in safe place.")
+	fmt.Println()
+	fmt.Println("Key location: " + basePath + "/" + OperatorKeyFolder + "/" + keyFileName)
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return err
+	}
+	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
+	fmt.Println("Public Key hex: ", hexutil.Encode(publicKeyBytes)[4:])
+	address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
+	fmt.Println("Ethereum Address", address)
+	return nil
 }
 
 func WriteEncryptedECDSAPrivateKeyToPath(keyName string, privateKey *ecdsa.PrivateKey, password string) error {

--- a/cli/operator/keys/create.go
+++ b/cli/operator/keys/create.go
@@ -44,7 +44,7 @@ func CreateCmd(p prompter.Prompter) *cobra.Command {
 		Long: `
 Used to create ecdsa and bls key in local keystore
 
-keyname (required) - This will be name of the created key file. It will be saved as <keyname>.ecdsa.key.json or <keyname>.bls.key.json
+keyname (required) - This will be the name of the created key file. It will be saved as <keyname>.ecdsa.key.json or <keyname>.bls.key.json
 
 use --key-type ecdsa/bls to create ecdsa/bls key. 
 It will prompt for password to encrypt the key, which is optional but highly recommended.

--- a/cli/operator/keys/error.go
+++ b/cli/operator/keys/error.go
@@ -3,9 +3,11 @@ package keys
 import "errors"
 
 var (
-	ErrInvalidNumberOfArgs    = errors.New("invalid number of arguments")
-	ErrEmptyKeyName           = errors.New("key cannot be empty")
-	ErrKeyContainsWhitespaces = errors.New("key cannot contain spaces")
-	ErrInvalidKeyType         = errors.New("invalid key type. key type must be either 'ecdsa' or 'bls'")
-	ErrInvalidPassword        = errors.New("invalid password")
+	ErrInvalidNumberOfArgs           = errors.New("invalid number of arguments")
+	ErrEmptyKeyName                  = errors.New("key name cannot be empty")
+	ErrEmptyPrivateKey               = errors.New("private key cannot be empty")
+	ErrKeyContainsWhitespaces        = errors.New("key name cannot contain spaces")
+	ErrPrivateKeyContainsWhitespaces = errors.New("private key cannot contain spaces")
+	ErrInvalidKeyType                = errors.New("invalid key type. key type must be either 'ecdsa' or 'bls'")
+	ErrInvalidPassword               = errors.New("invalid password")
 )

--- a/cli/operator/keys/import.go
+++ b/cli/operator/keys/import.go
@@ -1,0 +1,185 @@
+package keys
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/NethermindEth/eigenlayer/cli/prompter"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/spf13/cobra"
+)
+
+func ImportCmd(p prompter.Prompter) *cobra.Command {
+	var (
+		keyType  string
+		insecure bool
+		help     bool
+	)
+
+	cmd := cobra.Command{
+		Use:   "import --key-type <key-type> [flags] <keyname> <private-key>",
+		Short: "Used to import existing keys in local keystore",
+		Long: `
+Used to import ecdsa and bls key in local keystore
+
+Command:
+	eigenlayer operator keys import --key-type <key-type> <keyname> <private-key>
+
+keyname and private-key is required
+
+use --key-type ecdsa/bls to create ecdsa/bls key. 
+- ecdsa - private-key should be hex encoded private key
+- bls - private-key should be bls private key
+
+It will prompt for password to encrypt the key, which is optional but highly recommended.
+If you want to import a key with weak/no password, use --insecure flag. Do NOT use those keys in production
+
+This command will create keys in ./operator_keys/ location
+		`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Parse static flags
+			cmd.DisableFlagParsing = false
+			cmd.FParseErrWhitelist.UnknownFlags = true // Don't show error for unknown flags to allow dynamic flags
+			err := cmd.ParseFlags(args)
+			if err != nil {
+				return err
+			}
+
+			// Skip execution if help flag is set
+			help, err = cmd.Flags().GetBool("help")
+			if err != nil {
+				return err
+			}
+			if help {
+				return nil
+			}
+
+			// Validate args
+			args = cmd.Flags().Args()
+			if len(args) != 2 {
+				return fmt.Errorf("%w: accepts 2 arg, received %d", ErrInvalidNumberOfArgs, len(args))
+			}
+
+			keyName := args[0]
+			if len(keyName) == 0 {
+				return ErrEmptyKeyName
+			}
+
+			if match, _ := regexp.MatchString("\\s", keyName); match {
+				return ErrKeyContainsWhitespaces
+			}
+
+			privateKey := args[1]
+			if len(privateKey) == 0 {
+				return ErrEmptyPrivateKey
+			}
+
+			if match, _ := regexp.MatchString("\\s", privateKey); match {
+				return ErrPrivateKeyContainsWhitespaces
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			keyName := args[0]
+			privateKey := args[1]
+			basePath, _ := os.Getwd()
+
+			switch keyType {
+			case KeyTypeECDSA:
+				keyFileName := keyName + ".ecdsa.key.json"
+				if checkIfKeyExists(keyFileName) {
+					return errors.New("key name already exists. Please choose a different name")
+				}
+
+				if strings.HasPrefix(privateKey, "0x") {
+					privateKey = privateKey[2:]
+				}
+
+				privateKeyPair, err := crypto.HexToECDSA(privateKey)
+				if err != nil {
+					return err
+				}
+
+				password, err := p.InputHiddenString("Enter password to encrypt the ecdsa private key:", "",
+					func(s string) error {
+						if insecure {
+							return nil
+						}
+						return validatePassword(s)
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				err = WriteEncryptedECDSAPrivateKeyToPath(keyFileName, privateKeyPair, password)
+				if err != nil {
+					return err
+				}
+
+				privateKeyHex := hex.EncodeToString(privateKeyPair.D.Bytes())
+				// TODO: display it using `less` of `vi` so that it is not saved in terminal history
+				fmt.Println("ECDSA Private Key (Hex): ", privateKeyHex)
+				fmt.Println("Please backup the above private key hex in safe place.")
+				fmt.Println()
+				fmt.Println("Key location: " + basePath + "/" + OperatorKeyFolder + "/" + keyFileName)
+				publicKey := privateKeyPair.Public()
+				publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+				if !ok {
+					return err
+				}
+				publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
+				fmt.Println(hexutil.Encode(publicKeyBytes)[4:])
+				address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
+				fmt.Println(address)
+
+				return nil
+			case KeyTypeBLS:
+				keyFileName := keyName + ".bls.key.json"
+				if checkIfKeyExists(keyFileName) {
+					return errors.New("key name already exists. Please choose a different name")
+				}
+				password, err := p.InputHiddenString("Enter password to encrypt the bls private key:", "",
+					func(s string) error {
+						if insecure {
+							return nil
+						}
+						return validatePassword(s)
+					},
+				)
+				if err != nil {
+					return err
+				}
+				blsKeyPair, err := bls.NewKeyPairFromString(privateKey)
+				if err != nil {
+					return err
+				}
+				err = blsKeyPair.SaveToFile(OperatorKeyFolder+"/"+keyFileName, password)
+				if err != nil {
+					return err
+				}
+				// TODO: display it using `less` of `vi` so that it is not saved in terminal history
+				fmt.Println("BLS Private Key: " + blsKeyPair.PrivKey.String())
+				fmt.Println("Please backup the above private key in safe place.")
+				fmt.Println()
+				fmt.Println("BLS Pub key: " + blsKeyPair.PubKey.String())
+				fmt.Println("Key location: " + basePath + "/" + OperatorKeyFolder + "/" + keyFileName)
+			default:
+				return ErrInvalidKeyType
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keyType, "key-type", "", "Type of key you want to create. Currently supports 'ecdsa' and 'bls'")
+	cmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Use this flag to skip password validation")
+
+	return &cmd
+}

--- a/cli/operator/keys/import.go
+++ b/cli/operator/keys/import.go
@@ -41,7 +41,7 @@ use --key-type ecdsa/bls to create ecdsa/bls key.
 It will prompt for password to encrypt the key, which is optional but highly recommended.
 If you want to import a key with weak/no password, use --insecure flag. Do NOT use those keys in production
 
-This command will create keys in ./operator_keys/ location
+This command will import keys in ./operator_keys/ location
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Parse static flags

--- a/cli/operator/keys/import.go
+++ b/cli/operator/keys/import.go
@@ -98,9 +98,7 @@ This command will import keys in ./operator_keys/ location
 					return errors.New("key name already exists. Please choose a different name")
 				}
 
-				if strings.HasPrefix(privateKey, "0x") {
-					privateKey = privateKey[2:]
-				}
+				privateKey = strings.TrimPrefix(privateKey, "0x")
 
 				privateKeyPair, err := crypto.HexToECDSA(privateKey)
 				if err != nil {

--- a/cli/operator/keys/import.go
+++ b/cli/operator/keys/import.go
@@ -24,7 +24,7 @@ func ImportCmd(p prompter.Prompter) *cobra.Command {
 		Long: `
 Used to import ecdsa and bls key in local keystore
 
-keyname (required) - This will be name of the imported key file. It will be saved as <keyname>.ecdsa.key.json or <keyname>.bls.key.json
+keyname (required) - This will be the name of the imported key file. It will be saved as <keyname>.ecdsa.key.json or <keyname>.bls.key.json
 
 use --key-type ecdsa/bls to import ecdsa/bls key. 
 - ecdsa - <private-key> should be plaintext hex encoded private key

--- a/cli/operator/keys/import.go
+++ b/cli/operator/keys/import.go
@@ -29,14 +29,11 @@ func ImportCmd(p prompter.Prompter) *cobra.Command {
 		Long: `
 Used to import ecdsa and bls key in local keystore
 
-Command:
-	eigenlayer operator keys import --key-type <key-type> <keyname> <private-key>
+keyname (required) - This will be name of the imported key file. It will be saved as <keyname>.ecdsa.key.json or <keyname>.bls.key.json
 
-keyname and private-key is required
-
-use --key-type ecdsa/bls to create ecdsa/bls key. 
-- ecdsa - private-key should be hex encoded private key
-- bls - private-key should be bls private key
+use --key-type ecdsa/bls to import ecdsa/bls key. 
+- ecdsa - <private-key> should be plaintext hex encoded private key
+- bls - <private-key> should be plaintext bls private key
 
 It will prompt for password to encrypt the key, which is optional but highly recommended.
 If you want to import a key with weak/no password, use --insecure flag. Do NOT use those keys in production

--- a/cli/operator/keys/import_test.go
+++ b/cli/operator/keys/import_test.go
@@ -1,9 +1,13 @@
 package keys
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
 	prompterMock "github.com/NethermindEth/eigenlayer/cli/prompter/mocks"
 	"github.com/golang/mock/gomock"
@@ -125,6 +129,16 @@ func TestImportCmd(t *testing.T) {
 				// Check if the error indicates that the file does not exist
 				if os.IsNotExist(err) {
 					assert.Failf(t, "file does not exist", "file %s does not exist", tt.keyPath)
+				}
+
+				if tt.args[1] == KeyTypeECDSA {
+					key, err := GetECDSAPrivateKey(tt.keyPath, "")
+					assert.NoError(t, err)
+					assert.Equal(t, strings.Trim(tt.args[3], "0x"), hex.EncodeToString(key.D.Bytes()))
+				} else if tt.args[1] == KeyTypeBLS {
+					key, err := bls.ReadPrivateKeyFromFile(tt.keyPath, "")
+					assert.NoError(t, err)
+					assert.Equal(t, tt.args[3], key.PrivKey.String())
 				}
 			} else {
 				assert.EqualError(t, err, tt.err.Error())

--- a/cli/operator/keys/import_test.go
+++ b/cli/operator/keys/import_test.go
@@ -1,0 +1,134 @@
+package keys
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	prompterMock "github.com/NethermindEth/eigenlayer/cli/prompter/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImportCmd(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		err        error
+		keyPath    string
+		promptMock func(p *prompterMock.MockPrompter)
+	}{
+		{
+			name: "no arguments",
+			args: []string{},
+			err:  fmt.Errorf("%w: accepts 2 arg, received 0", ErrInvalidNumberOfArgs),
+		},
+		{
+			name: "one argument",
+			args: []string{"arg1"},
+			err:  fmt.Errorf("%w: accepts 2 arg, received 1", ErrInvalidNumberOfArgs),
+		},
+
+		{
+			name: "more than two argument",
+			args: []string{"arg1", "arg2", "arg3"},
+			err:  fmt.Errorf("%w: accepts 2 arg, received 3", ErrInvalidNumberOfArgs),
+		},
+		{
+			name: "empty key name argument",
+			args: []string{"", ""},
+			err:  ErrEmptyKeyName,
+		},
+		{
+			name: "keyname with whitespaces",
+			args: []string{"hello world", ""},
+			err:  ErrKeyContainsWhitespaces,
+		},
+		{
+			name: "empty private key argument",
+			args: []string{"hello", ""},
+			err:  ErrEmptyPrivateKey,
+		},
+		{
+			name: "keyname with whitespaces",
+			args: []string{"hello", "hello world"},
+			err:  ErrPrivateKeyContainsWhitespaces,
+		},
+		{
+			name: "invalid keytype",
+			args: []string{"--key-type", "invalid", "hello", "privkey"},
+			err:  ErrInvalidKeyType,
+		},
+		{
+			name: "invalid password based on validation function - ecdsa",
+			args: []string{"--key-type", "ecdsa", "test", "6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6"},
+			err:  ErrInvalidPassword,
+			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", ErrInvalidPassword)
+			},
+		},
+		{
+			name: "invalid password based on validation function - bls",
+			args: []string{"--key-type", "bls", "test", "privkey"},
+			err:  ErrInvalidPassword,
+			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", ErrInvalidPassword)
+			},
+		},
+		{
+			name: "valid ecdsa key import",
+			args: []string{"--key-type", "ecdsa", "test", "6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6"},
+			err:  nil,
+			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+			},
+			keyPath: OperatorKeyFolder + "/test.ecdsa.key.json",
+		},
+		{
+			name: "valid ecdsa key import with 0x prefix",
+			args: []string{"--key-type", "ecdsa", "test", "0x6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6"},
+			err:  nil,
+			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+			},
+			keyPath: OperatorKeyFolder + "/test.ecdsa.key.json",
+		},
+		{
+			name: "valid bls key import",
+			args: []string{"--key-type", "bls", "test", "20030410000080487431431153104351076122223465926814327806350179952713280726583"},
+			err:  nil,
+			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+			},
+			keyPath: OperatorKeyFolder + "/test.bls.key.json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				_ = os.RemoveAll(OperatorKeyFolder)
+			})
+			controller := gomock.NewController(t)
+			p := prompterMock.NewMockPrompter(controller)
+			if tt.promptMock != nil {
+				tt.promptMock(p)
+			}
+
+			importCmd := ImportCmd(p)
+			importCmd.SetArgs(tt.args)
+			err := importCmd.Execute()
+
+			if tt.err == nil {
+				assert.NoError(t, err)
+				_, err := os.Stat(tt.keyPath)
+
+				// Check if the error indicates that the file does not exist
+				if os.IsNotExist(err) {
+					assert.Failf(t, "file does not exist", "file %s does not exist", tt.keyPath)
+				}
+			} else {
+				assert.EqualError(t, err, tt.err.Error())
+			}
+		})
+	}
+}

--- a/cli/operator/keys/import_test.go
+++ b/cli/operator/keys/import_test.go
@@ -69,7 +69,7 @@ func TestImportCmd(t *testing.T) {
 		},
 		{
 			name: "invalid password based on validation function - bls",
-			args: []string{"--key-type", "bls", "test", "privkey"},
+			args: []string{"--key-type", "bls", "test", "123"},
 			err:  ErrInvalidPassword,
 			promptMock: func(p *prompterMock.MockPrompter) {
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", ErrInvalidPassword)


### PR DESCRIPTION
Fixes | Closes | Resolves #

Feature to import existing key for use by CLI

## Changes:
- Import both bls and ecdsa key

## Types of changes

_Leave on the following list the types of changes introduced by this PR and remove
the ones that don't apply. Please also remove this line._

- New feature (non-breaking change which adds functionality)
- 
## Testing

**Requires testing** Yes/No

**In case you checked yes, did you write tests?** Yes/No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
