### PR TITLE
Fix update dynamic flags

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -131,7 +131,12 @@ could be restored manually using the 'eigenlayer restore' command.`,
 
 			// Build dynamic flags with the profile options
 			for _, o := range pullResult.MergedOptions {
-				cmd.Flags().String("option."+o.Name(), o.Default(), o.Help())
+				v, err := o.Value()
+				if err != nil {
+					cmd.Flags().String("option."+o.Name(), o.Default(), o.Help())
+				} else {
+					cmd.Flags().String("option."+o.Name(), v, o.Help())
+				}
 			}
 
 			// Parse dynamic flags

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -33,9 +33,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -86,9 +85,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -141,9 +139,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -197,9 +194,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -252,9 +248,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -295,9 +290,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -340,9 +334,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -385,9 +378,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(
@@ -439,9 +431,8 @@ func TestUpdate(t *testing.T) {
 				oldOption.EXPECT().Value().Return("old-value", nil)
 				oldOption.EXPECT().Name().Return("old-option").Times(3)
 				mergedOption.EXPECT().IsSet().Return(true).Times(2)
-				mergedOption.EXPECT().Value().Return("old-value", nil)
+				mergedOption.EXPECT().Value().Return("old-value", nil).Times(2)
 				mergedOption.EXPECT().Name().Return("old-option").Times(2)
-				mergedOption.EXPECT().Default().Return("default-value")
 				mergedOption.EXPECT().Help().Return("option help")
 
 				gomock.InOrder(

--- a/e2e/backup_test.go
+++ b/e2e/backup_test.go
@@ -78,7 +78,7 @@ func TestBackupList(t *testing.T) {
 			t.Log(string(out))
 			assert.NoError(t, backupErr, "backup ls command should succeed")
 			assert.Regexp(t, regexp.MustCompile(`ID\s+AVS Instance ID\s+VERSION\s+COMMIT\s+TIMESTAMP\s+SIZE\s+URL\s+`+
-				`[a-f0-9]+\s+mock-avs-default\s+v5\.5\.1\s+d5af645fffb93e8263b099082a4f512e1917d0af\s+.*\s+10KiB\s+https://github.com/NethermindEth/mock-avs-pkg\s+`),
+				`[a-f0-9]+\s+mock-avs-default\s+`+common.MockAvsPkg.Version()+`\s+`+common.MockAvsPkg.CommitHash()+`\s+.*\s+10KiB\s+https://github.com/NethermindEth/mock-avs-pkg\s+`),
 				string(out))
 		},
 	)


### PR DESCRIPTION
## Changes:

- Fix dynamic options flags in the update procees. The default value of the flag should be the current option value if it has one. If not, the default option value should be used.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing** Yes/No

**In case you checked yes, did you write tests?** No, the current tests are updated.

