### PR TITLE
Print etherscan links on on-chain interactions

### DIFF
--- a/cli/operator/update.go
+++ b/cli/operator/update.go
@@ -119,7 +119,7 @@ func UpdateCmd(p prompter.Prompter) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Println("Operator bls key added transaction at:", getTransactionLink(receipt.TxHash.String(), &operatorCfg.ChainId))
+			fmt.Println("Operator details updated at:", getTransactionLink(receipt.TxHash.String(), &operatorCfg.ChainId))
 
 			fmt.Println("Operator updated successfully")
 			return nil

--- a/cli/operator/update.go
+++ b/cli/operator/update.go
@@ -115,10 +115,12 @@ func UpdateCmd(p prompter.Prompter) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, err = elWriter.UpdateOperatorDetails(context.Background(), operatorCfg.Operator)
+			receipt, err := elWriter.UpdateOperatorDetails(context.Background(), operatorCfg.Operator)
 			if err != nil {
 				return err
 			}
+			fmt.Println("Operator bls key added transaction at:", getTransactionLink(receipt.TxHash.String(), &operatorCfg.ChainId))
+
 			fmt.Println("Operator updated successfully")
 			return nil
 		},


### PR DESCRIPTION
Closes #123 

This PR updates all on-chain commands done by the `ELWriter` to log etherscan links.

## Changes:
Print statements on on-chain interactions with etherscan/goerli-scan links. 

## Types of changes
- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing** No
