### PR TITLE
Prompt Operator when creating Config File

### DIFF
--- a/cli/operator.go
+++ b/cli/operator.go
@@ -16,7 +16,7 @@ func OperatorCmd(p prompter.Prompter) *cobra.Command {
 		operator.RegisterCmd(p),
 		operator.UpdateCmd(p),
 		operator.StatusCmd(),
-		operator.ConfigCmd(),
+		operator.ConfigCmd(p),
 		operator.KeysCmd(p),
 	)
 	return &cmd

--- a/cli/operator/config.go
+++ b/cli/operator/config.go
@@ -2,16 +2,17 @@ package operator
 
 import (
 	"github.com/NethermindEth/eigenlayer/cli/operator/config"
+	"github.com/NethermindEth/eigenlayer/cli/prompter"
 	"github.com/spf13/cobra"
 )
 
-func ConfigCmd() *cobra.Command {
+func ConfigCmd(p prompter.Prompter) *cobra.Command {
 	cmd := cobra.Command{
 		Use: "config",
 	}
 
 	cmd.AddCommand(
-		config.CreateCmd(),
+		config.CreateCmd(p),
 	)
 
 	return &cmd

--- a/cli/operator/config/create.go
+++ b/cli/operator/config/create.go
@@ -2,18 +2,26 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
 	"os"
+	"regexp"
+	"strings"
 
 	eigensdkTypes "github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/NethermindEth/eigenlayer/cli/prompter"
 	"github.com/NethermindEth/eigenlayer/internal/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
-func CreateCmd() *cobra.Command {
+const zeroAddress = "0x0000000000000000000000000000000000000000"
+
+func CreateCmd(p prompter.Prompter) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "create",
-		Short: "Used to creata operator config and metadata json sample file",
+		Short: "Used to create operator config and metadata json sample file",
 		Long: `
 		This command is used to create a sample empty operator config file 
 		and also an empty metadata json file which you need to upload for
@@ -23,6 +31,21 @@ func CreateCmd() *cobra.Command {
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			op := types.OperatorConfig{}
+
+			// Prompt user to generate empty or non-empty files
+			populate, err := p.Confirm("Would you like to populate the operator config file?")
+			if err != nil {
+				return err
+			}
+
+			if populate {
+				op, err = promptOperatorInfo(&op, p)
+				fmt.Println("op: ", op)
+				if err != nil {
+					return err
+				}
+			}
+
 			yamlData, err := yaml.Marshal(&op)
 			if err != nil {
 				return err
@@ -38,6 +61,7 @@ func CreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			metadataFile := "metadata.json"
 			err = os.WriteFile(metadataFile, jsonData, 0o644)
 			if err != nil {
@@ -48,4 +72,115 @@ func CreateCmd() *cobra.Command {
 	}
 
 	return &cmd
+}
+
+func promptOperatorInfo(config *types.OperatorConfig, p prompter.Prompter) (types.OperatorConfig, error) {
+	// Prompt and set operator address
+	operatorAddress, err := p.InputString("Enter your operator address:", "", "",
+		func(s string) error {
+			return validateAddressIsNonZeroAndValid(s)
+		},
+	)
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+	config.Operator.Address = operatorAddress
+
+	// Prompt to gate stakers approval
+	gateApproval, err := p.Confirm("Do you want to gate stakers approval?")
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+
+	// Prompt for address if operator wants to gate approvals
+	if gateApproval {
+		delegationApprover, err := p.InputString("Enter your staker approver address:", "", "",
+			func(s string) error {
+				return validateAddress(s)
+			},
+		)
+		if err != nil {
+			return types.OperatorConfig{}, err
+		}
+		config.Operator.DelegationApproverAddress = delegationApprover
+	} else {
+		config.Operator.DelegationApproverAddress = zeroAddress
+	}
+
+	// Prompt and set earnings address
+	earningsAddress, err := p.InputString("Enter your earnings address:", config.Operator.Address, "",
+		func(s string) error {
+			return validateAddressIsNonZeroAndValid(s)
+		},
+	)
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+	config.Operator.EarningsReceiverAddress = earningsAddress
+
+	// Prompt for eth node
+	rpcUrl, err := p.InputString("Enter your rpc url:", "", "",
+		func(s string) error { return nil },
+	)
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+	config.EthRPCUrl = rpcUrl
+
+	// Prompt for ecdsa key path
+	ecdsaKeyPath, err := p.InputString("Enter your ecdsa key path:", "", "",
+		func(s string) error { return nil },
+	)
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+	config.PrivateKeyStorePath = ecdsaKeyPath
+
+	// Prompt for bls key path
+	blsKeyPath, err := p.InputString("Enter your bls key path:", "", "",
+		func(s string) error { return nil },
+	)
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+	config.BlsPrivateKeyStorePath = blsKeyPath
+
+	// Prompt for network & set chainId
+	chainId, err := p.Select("Select your network:", []string{"mainnet", "goerli", "local"})
+	if err != nil {
+		return types.OperatorConfig{}, err
+	}
+
+	switch chainId {
+	case "mainnet":
+		config.ChainId = *big.NewInt(1)
+	case "goerli":
+		config.ChainId = *big.NewInt(5)
+	case "local":
+		config.ChainId = *big.NewInt(31337)
+	}
+
+	return *config, nil
+}
+
+func validateAddressIsNonZeroAndValid(address string) error {
+	if address == zeroAddress {
+		return errors.New("address is 0")
+	}
+
+	return validateAddress(address)
+}
+
+func validateAddress(address string) error {
+	// Remove 0x
+	address = strings.TrimPrefix(address, "0x")
+
+	// Check if address has 40 hexadecimal characters
+	isValid, _ := regexp.MatchString("^[0-9a-fA-F]{40}$", address)
+
+	if !isValid {
+		return errors.New("invalid address")
+	}
+
+	return nil
 }

--- a/cli/operator/config/create.go
+++ b/cli/operator/config/create.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"os"
 	"regexp"
@@ -40,7 +39,6 @@ func CreateCmd(p prompter.Prompter) *cobra.Command {
 
 			if populate {
 				op, err = promptOperatorInfo(&op, p)
-				fmt.Println("op: ", op)
 				if err != nil {
 					return err
 				}

--- a/internal/hardware_checker/hardware_checker.go
+++ b/internal/hardware_checker/hardware_checker.go
@@ -53,14 +53,14 @@ func GetMetrics() (hardwareMetrics HardwareMetrics, err error) {
 	cpuCores := runtime.NumCPU()
 	hardwareMetrics.CPU = float64(cpuCores)
 
-	// Total Memory RAM
-	// memInfo := &syscall.Sysinfo_t{}
-	// err = syscall.Sysinfo(memInfo)
-	// if err != nil {
-	// 	return hardwareMetrics, fmt.Errorf("failed to get memory info: %w", err)
-	// }
-	// totalMemory := float64(memInfo.Totalram*uint64(memInfo.Unit)) / (1024 * 1024) // Convert to Mb
-	// hardwareMetrics.RAM = totalMemory
+	Total Memory RAM
+	memInfo := &syscall.Sysinfo_t{}
+	err = syscall.Sysinfo(memInfo)
+	if err != nil {
+		return hardwareMetrics, fmt.Errorf("failed to get memory info: %w", err)
+	}
+	totalMemory := float64(memInfo.Totalram*uint64(memInfo.Unit)) / (1024 * 1024) // Convert to Mb
+	hardwareMetrics.RAM = totalMemory
 
 	// Disk Free Space
 	wd, err := os.Getwd()

--- a/internal/hardware_checker/hardware_checker.go
+++ b/internal/hardware_checker/hardware_checker.go
@@ -54,13 +54,13 @@ func GetMetrics() (hardwareMetrics HardwareMetrics, err error) {
 	hardwareMetrics.CPU = float64(cpuCores)
 
 	// Total Memory RAM
-	memInfo := &syscall.Sysinfo_t{}
-	err = syscall.Sysinfo(memInfo)
-	if err != nil {
-		return hardwareMetrics, fmt.Errorf("failed to get memory info: %w", err)
-	}
-	totalMemory := float64(memInfo.Totalram*uint64(memInfo.Unit)) / (1024 * 1024) // Convert to Mb
-	hardwareMetrics.RAM = totalMemory
+	// memInfo := &syscall.Sysinfo_t{}
+	// err = syscall.Sysinfo(memInfo)
+	// if err != nil {
+	// 	return hardwareMetrics, fmt.Errorf("failed to get memory info: %w", err)
+	// }
+	// totalMemory := float64(memInfo.Totalram*uint64(memInfo.Unit)) / (1024 * 1024) // Convert to Mb
+	// hardwareMetrics.RAM = totalMemory
 
 	// Disk Free Space
 	wd, err := os.Getwd()

--- a/internal/hardware_checker/hardware_checker.go
+++ b/internal/hardware_checker/hardware_checker.go
@@ -53,7 +53,7 @@ func GetMetrics() (hardwareMetrics HardwareMetrics, err error) {
 	cpuCores := runtime.NumCPU()
 	hardwareMetrics.CPU = float64(cpuCores)
 
-	Total Memory RAM
+	// Total Memory RAM
 	memInfo := &syscall.Sysinfo_t{}
 	err = syscall.Sysinfo(memInfo)
 	if err != nil {

--- a/internal/types/operator_config.go
+++ b/internal/types/operator_config.go
@@ -23,3 +23,25 @@ type OperatorConfig struct {
 	BlsPrivateKeyStorePath        string                 `yaml:"bls_private_key_store_path"`
 	ChainId                       big.Int                `yaml:"chain_id"`
 }
+
+func (config OperatorConfig) MarshalYAML() (interface{}, error) {
+	return struct {
+		Operator                      eigensdkTypes.Operator `yaml:"operator"`
+		ELSlasherAddress              string                 `yaml:"el_slasher_address"`
+		BlsPublicKeyCompendiumAddress string                 `yaml:"bls_public_key_compendium_address"`
+		EthRPCUrl                     string                 `yaml:"eth_rpc_url"`
+		PrivateKeyStorePath           string                 `yaml:"private_key_store_path"`
+		SignerType                    SignerType             `yaml:"signer_type"`
+		BlsPrivateKeyStorePath        string                 `yaml:"bls_private_key_store_path"`
+		ChainID                       int64                  `yaml:"chain_id"`
+	}{
+		Operator:                      config.Operator,
+		ELSlasherAddress:              config.ELSlasherAddress,
+		BlsPublicKeyCompendiumAddress: config.BlsPublicKeyCompendiumAddress,
+		EthRPCUrl:                     config.EthRPCUrl,
+		PrivateKeyStorePath:           config.PrivateKeyStorePath,
+		SignerType:                    config.SignerType,
+		BlsPrivateKeyStorePath:        config.BlsPrivateKeyStorePath,
+		ChainID:                       config.ChainId.Int64(),
+	}, nil
+}


### PR DESCRIPTION
Closes #116 

When an operator creates a config file via the `eigenlayer operator config create` command, we now prompt the operator with fields that will populate the config file.

## Changes:
Updates to the `operator/create.go` logic to prompt an operator.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing** No